### PR TITLE
Adding missing privacy strings.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -71,8 +71,8 @@ class provider implements
         $items->add_database_table(
             'verbalfeedback_response',
             [
-                'instanceid' => 'privacy:metadata:verbalfeedback',
-                'submissionid' => 'privacy:metadata:verbalfeedback_submissionid',
+                'instanceid' => 'privacy:metadata:instanceid',
+                'submissionid' => 'privacy:metadata:verbalfeedback_submission:id',
                 'fromuserid' => 'privacy:metadata:verbalfeedback_submission:fromuserid',
                 'touserid' => 'privacy:metadata:verbalfeedback_submission:touserid',
                 'value' => 'privacy:metadata:verbalfeedback_response:value',

--- a/lang/en/verbalfeedback.php
+++ b/lang/en/verbalfeedback.php
@@ -155,6 +155,7 @@ $string['privacy:metadata:verbalfeedback_response'] = 'This table stores the res
 $string['privacy:metadata:verbalfeedback_response:value'] = 'The value of the respondent\'s response to the feedback question';
 $string['privacy:metadata:verbalfeedback_submission'] = 'This table stores the information about the statuses of verbal feedback submissions between the participants';
 $string['privacy:metadata:verbalfeedback_submission:fromuserid'] = 'The user ID of the person giving the feedback';
+$string['privacy:metadata:verbalfeedback_submission:id'] = 'The ID of the verbal feedback submission';
 $string['privacy:metadata:verbalfeedback_submission:remarks'] = 'The reason why the respondent declined to give feedback to the feedback recipient';
 $string['privacy:metadata:verbalfeedback_submission:status'] = 'The status of the feedback submission';
 $string['privacy:metadata:verbalfeedback_submission:touserid'] = 'The user ID of the feedback recipient';


### PR DESCRIPTION
Without this, the page admin/tool/dataprivacy/pluginregistry.php breaks because of missing language strings.